### PR TITLE
Replace ts_ls with tsserver

### DIFF
--- a/lua/plugins/lsp-config.lua
+++ b/lua/plugins/lsp-config.lua
@@ -27,9 +27,9 @@ return {
 				capabilities = capabilities,
 			})
 
-			lspconfig.ts_ls.setup({
-				capabilities = capabilities,
-			})
+                        lspconfig.tsserver.setup({
+                                capabilities = capabilities,
+                        })
 
 			lspconfig.dockerls.setup({
 				capabilities = capabilities,


### PR DESCRIPTION
## Summary
- fix TypeScript language server configuration by using `tsserver` instead of the non-existent `ts_ls`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_687138ae83408329a3656f44f100baf4