### PR TITLE
Fix NeoTree comments

### DIFF
--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -13,9 +13,9 @@ return {
 		configTree.setup({
 			filesystem = {
 				filtered_items = {
-					visible = true, -- Mostrar archivos ocultos
-					hide_dotfiles = false, -- No ocultar archivos que empiezan con `.`
-					hide_gitignored = false, -- Mostrar archivos ignorados por git
+                                        visible = true, -- Show hidden files
+                                        hide_dotfiles = false, -- Do not hide files starting with `.`
+                                        hide_gitignored = false, -- Show git-ignored files
 				},
 			},
 		})


### PR DESCRIPTION
## Summary
- translate NeoTree plugin comments from Spanish to English

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687139cf73148329b272787378d73c37