### PR TITLE
Fix plugin list typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/erickGoJi/my-nvim-config.git ~/.config/nvim
 
 ## Plugins
 
-1. Alpa
+1. Alpha
 2. Catppuccino
 3. Completion-nvim
 4. Copilot


### PR DESCRIPTION
## Summary
- fix the "Alpa" typo in README plugin list

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687139ce66448329bbadab5f372b65d6