### PR TITLE
Add vim option tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ git clone https://github.com/erickGoJi/my-nvim-config.git ~/.config/nvim
 9. Telescope
 10. Treesitter
 
+
+## Testing
+
+Run the test suite with:
+```bash
+nvim --headless -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }"
+```

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,2 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+vim.opt.runtimepath:append(vim.fn.stdpath('data') .. '/lazy/plenary.nvim')

--- a/tests/vim_options_spec.lua
+++ b/tests/vim_options_spec.lua
@@ -1,0 +1,17 @@
+require('plenary.busted')
+
+describe('vim-options', function()
+  before_each(function()
+    package.loaded['vim-options'] = nil
+    require('vim-options')
+  end)
+
+  it('sets mapleader to space', function()
+    assert.equals(' ', vim.g.mapleader)
+  end)
+
+  it('sets clipboard to unnamedplus', function()
+    assert.equals('unnamedplus', vim.o.clipboard)
+  end)
+end)
+


### PR DESCRIPTION
## Summary
- add plenary-based tests checking that vim-options sets `mapleader` and `clipboard`
- document how to run the tests

## Testing
- `nvim --headless -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687139d380108329b11c18103bbe062b